### PR TITLE
Introdução de exemplo do webphone usando React

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,18 @@ Para configurar o seu webphone neste script você deve:
 <!-- URL que foi pega pela API no /webphone - cria o iframe e injeta o webphone-->
 <script src="URL_WEBPHONE_API_TOTALVOICE"></script>
 ```
+
+### Utilização do webphone com React
+
+Siga os passos citados anteriormente para gerar a URL do seu webphone, no entanto, informe sempre o tipo como EMBEDDED.
+* adicione a url gerada no valor do src no iframe do index.js dentro da pasta webphone-REACT
+```
+<iframe
+  allow="microphone"
+  src="URL_WEBPHONE_API_TOTALVOICE"
+  style={{ display: 'none' }}
+  ref={webphoneRef}
+  />
+```
+* mantenha na estilização do iframe o `display: none` se quiser criar seus próprios componentes para o webphone ou tire esta opção se preferir utilizar o visual padrão do webphone embedded
+* para rodar o projeto, acesse a pasta webphone-REACT, utilize `npm install ` para instalar as dependências e utilize `npm run dev` para rodar em modo de desenvolvimento ou `npm run build ` para gerar um build otimizado dentro da pasta `public ` 

--- a/webphone-REACT/.gitignore
+++ b/webphone-REACT/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+yarn.lock
+package-lock.json

--- a/webphone-REACT/babel.config.js
+++ b/webphone-REACT/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    '@babel/preset-env',
+    '@babel/preset-react'
+  ]
+}

--- a/webphone-REACT/index.js
+++ b/webphone-REACT/index.js
@@ -1,0 +1,161 @@
+import React from 'react';
+
+import ReactDOM from 'react-dom';
+
+const Webphone = () => {
+  const webphoneRef = React.useRef(null);
+
+  const windowListener = e => {
+    //quando receber uma ligacao
+    if (e.data.message == 'chegandoChamada') {
+        alert('Chegando Chamada de ' + e.data.numeroChegando + ' para: ' + e.data.numeroDestino + ' chamada_recebida_id: ' + e.data.chamadaRecebidaId);
+    }
+    //conectado, desconectado, chamando, encerrada, conversando
+    if (e.data.message == 'status') {
+        //alert('Status: ' + e.data.status);
+    }
+    //o id é único e pode ser utilizado na api para recuperação de mais informações (get na api ou webhooks) 
+    if (e.data.message == 'chamada_id') {
+        alert('Chamada_id: ' + e.data.chamada_id);
+    }
+    //os erros são finais
+    if (e.data.message == 'status_erro') {
+        //alert('Sem Permissão: ' + e.data.status_erro);
+    }
+    
+    //rebendo o status de diagnóstico de internet e computador para verificar qualidade de ligação
+    if (e.data.message == 'stats_webphone') {
+        //alert('Internet: ' + e.data.internet + ' e computador: ' + e.data.computador);
+    }
+  };
+
+  //encerra chamada ativa
+  function desligaChamada() {
+    webphoneRef.current.contentWindow.postMessage({
+        message: 'hangup'
+    }, '*');
+  }
+  
+  //Conecta o webphone para coloca-lo em operação
+  function conectar(){
+      webphoneRef.current.contentWindow.postMessage({message : 'conectar'}, '*');
+  }
+
+  //desconecta o webphone - ele nao recebe nem envia mais chamadas
+  function desconectar(){
+      webphoneRef.current.contentWindow.postMessage({message : 'desconectar'}, '*');
+  }
+
+
+  //telefona para um número
+  function chamaNumero(numero) {
+      webphoneRef.current.contentWindow.postMessage({
+          message: 'chamaNumero',
+          'numero': numero
+      }, '*');
+  }
+
+  //atender
+  function atender() {
+      webphoneRef.current.contentWindow.postMessage({
+          message: 'answer'
+      }, '*');
+  }
+
+  //para uso com uras
+  function enviaDTMF(meuDTMF) {
+      webphoneRef.current.contentWindow.postMessage({
+          message: 'enviaDTMF',
+          'dtmf': meuDTMF
+      }, '*');
+  }
+
+  //mute microfone
+  function mute() {
+      webphoneRef.current.contentWindow.postMessage({
+          message: 'mute'
+      }, '*');
+  }
+
+  //transferencia blind - encerra a ligação aqui e transfere para o numero
+  function transferir(numeroTelefone) {
+      webphoneRef.current.contentWindow.postMessage({
+          message: 'transferir',
+          'numeroTelefone': numeroTelefone
+      }, '*');
+  }
+
+  //transferencia com consulta
+  function transferirConsulta(numeroTelefone) {
+      webphoneRef.current.contentWindow.postMessage({
+          message: 'transferirConsulta',
+          'numeroTelefone': numeroTelefone
+      }, '*');
+  }
+
+  function recstart() {
+      webphoneRef.current.contentWindow.postMessage({
+          message: 'recStart'
+      }, '*');
+  }
+
+  function recstop() {
+      webphoneRef.current.contentWindow.postMessage({
+          message: 'recStop'
+      }, '*');                
+  }
+
+  React.useEffect(() => {
+    if (webphoneRef.current) {
+      window.addEventListener('message', windowListener);
+
+      // remove o event listener quando o componente for unmounted
+      return () => window.removeEventListener('message', windowListener);
+    }
+
+  },[webphoneRef.current]);
+
+  return (
+    <React.Fragment>
+        <iframe
+            allow="microphone"
+            src="URL_WEBPHONE_API_TOTALVOICE"
+            style={{ display: 'none' }}
+            ref={webphoneRef}
+        />
+          <br />
+        <input type="button" onClick={conectar} value="Conectar" /> (o sistema conecta sozinho por default ao abrir)<br />
+        <input type="button" onClick={desconectar} value="Desconectar" /> (nao recebe nem faz mais chamadas)<br />
+        <input type="button" onClick={desligaChamada} value="Desliga" />
+        <input type="button" onClick={() => chamaNumero(4001)} value="Chama 4001" />
+        <br />
+        <input type="button" onClick={() => chamaNumero(4832830151)} value="Chama 4832830151" />
+        <br />
+        <input type="button" onClick={() => chamaNumero(97988888888)} value="Chama 97988888888" />
+        <br /> (DTMF: 0,1,2,3,4,5,6,7,8,9,*,#)<br />
+        <input type="button" onClick={() => enviaDTMF('1')} value="DTMF 1" />
+        <br />
+        <input type="button" onClick={() => enviaDTMF('2')} value="DTMF 2" />
+        <br />
+        <input type="button" onClick={() => enviaDTMF('0')} value="DTMF 0" />
+        <br />
+        <input type="button" onClick={() => enviaDTMF('*')} value="DTMF *" />
+        <br />
+        <input type="button" onClick={() => enviaDTMF('#')} value="DTMF #" />
+        <br /><input type="button" onClick={mute} value="Mute/Unmute" />
+        <br />
+        <br />
+        <input type="button" onClick={() => transferirConsulta('4000')} value="Transferir Consulta para 4998" />
+        <br />
+        <input type="button" onClick={() => transferir('4515')} value="Transferir para 4515" />
+        <input type="button" onClick={atender} value="Atender" />C
+        <br />
+        <br />
+        <input type="button" onClick={recstart} value="REC Start" />
+        <input type="button" onClick={recstop} value="REC Stop" />
+    </React.Fragment>
+   
+  );
+};
+
+ReactDOM.render(<Webphone />, document.getElementById('totalvoice'));

--- a/webphone-REACT/package.json
+++ b/webphone-REACT/package.json
@@ -1,0 +1,19 @@
+{
+  "scripts": {
+    "build": "webpack --mode production",
+    "dev": "webpack-dev-server --mode development"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.8.4",
+    "@babel/preset-env": "^7.8.4",
+    "@babel/preset-react": "^7.8.3",
+    "babel-loader": "^8.0.6",
+    "webpack": "^4.41.5",
+    "webpack-cli": "^3.3.10",
+    "webpack-dev-server": "^3.10.2"
+  },
+  "dependencies": {
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
+  }
+}

--- a/webphone-REACT/public/index.html
+++ b/webphone-REACT/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Totalvoice React</title>
+</head>
+<body>
+  <div id="totalvoice"></div>
+
+  <script src="bundle.js"></script>
+</body>
+</html>

--- a/webphone-REACT/webpack.config.js
+++ b/webphone-REACT/webpack.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+module.exports = {
+  entry: path.join(__dirname, 'index.js'),
+  output: {
+    path: path.resolve(__dirname, 'public'),
+    filename: 'bundle.js'
+  },
+  devServer: {
+    contentBase: path.join(__dirname, 'public')
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader'
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Estive utilizando o webphone em alguns projetos com ReactJS e senti falta de exemplos para o meu caso no início. Decidi criar dentro da pasta webphone-REACT uma estrutura básica com babel e webpack que roda um exemplo de implementação do webphone TotalVoice utilizando react hooks e chamando suas funções através do ref.

O intuito é demonstrar uma forma simples de integrar o webphone embedded no react baseado nos outros exemplos e dando também a possibilidade de ser utilizado com a estrutura própria do webphone ou criando o próprio layout